### PR TITLE
timeout for wait_for_op() method; implement subscription->unsubscribe()

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ $subscription = $client->subscribe('foo', sub {
 # Process pending operations
 $client->wait_for_op();
 
+# Process pending operations, with a timeout (in seconds)
+# A timeout of 0 is polling.
+$client->wait_for_op(3.14);
+
 # Unsubscribe
 $subscription->unsubscribe();
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ $subscription = $client->subscribe('foo', sub {
     printf("Received a message: %s\n", $message->data);
 });
 
-# Process pending operations
+# Process one message from the server. Could be a PING message.
+# Must call at least one per ping-timout (default is 120s).
 $client->wait_for_op();
 
-# Process pending operations, with a timeout (in seconds)
+# Process pending operations, with a timeout (in seconds).
 # A timeout of 0 is polling.
 $client->wait_for_op(3.14);
 

--- a/lib/Net/NATS/Subscription.pm
+++ b/lib/Net/NATS/Subscription.pm
@@ -24,4 +24,9 @@ sub auto_unsubscribe {
     $self->client->unsubscribe($self, $max_msgs);
 }
 
+sub unsubscribe {
+    my $self = shift;
+    $self->client->unsubscribe($self);
+}
+
 1;


### PR DESCRIPTION
The unsubscribe method is documented in the README but did not in reality exist.

The timeout in wait_for_op() is useful when doing a work loop interacting with other services.
