### PR TITLE
fix timout by using our own input buffer

### DIFF
--- a/lib/Net/NATS/Client.pm
+++ b/lib/Net/NATS/Client.pm
@@ -8,7 +8,6 @@ use Class::XSAccessor {
     constructors => [ '_new' ],
     accessors => [
         'connection',
-        '_socket',
         'socket_args',
         'subscriptions',
         'uri',
@@ -54,7 +53,7 @@ sub connect {
 
     my $connection = Net::NATS::Connection->new(socket_args => $self->socket_args)
         or return;
-    $self->_socket($connection->_socket);
+    $self->connection($connection);
 
     # Get INFO line
     my ($op, @args) = $self->read_line;
@@ -78,7 +77,7 @@ sub connect {
         $connection->upgrade()
             or return;
 
-        $self->_socket($connection->_socket);
+        $self->connection($connection);
     }
 
     my $connect = 'CONNECT ' . to_json($connect_info, { convert_blessed => 1});
@@ -135,12 +134,12 @@ sub unsubscribe {
 # 0:$self 1:$subject 2:$data 3:$reply_to
 sub publish {
     my $reply_to = defined $_[3] ? $_[3].' ' : '';
-    syswrite $_[0]->_socket, 'PUB '.$_[1].' '.$reply_to.length($_[2])."\r\n".$_[2]."\r\n";
+    syswrite $_[0]->connection->_socket, 'PUB '.$_[1].' '.$reply_to.length($_[2])."\r\n".$_[2]."\r\n";
 }
 
 sub request {
     my ($self, $subject, $data, $callback) = @_;
-    
+
     my $inbox = new_inbox();
     my $sub = $self->subscribe($inbox, $callback);
     $self->unsubscribe($sub, 1);
@@ -153,20 +152,40 @@ sub _remove_subscription {
     delete $self->subscriptions->{$subscription->sid};
 }
 
+# blocking read built upon non-blocking read
 sub read {
     my ($self, $length) = @_;
 
     my $data;
-    $self->_socket->read($data, $length)
-        or return;
+    my $rv = $self->connection->nb_read($data, $length);
+    return unless $rv;          # EOF or error
+
+    if ($rv eq '0E0') {
+      while ($rv eq '0E0' && $self->connection->can_read()) { # keep trying until we get the data we need.
+        $rv = $self->connection->nb_read($data,$length);
+        return unless $rv;        # EOF or error. should report error somewhere...
+      }
+      return if $rv eq '0E0';   # got timeout from can_read
+    }
     $data =~ s/\r\n$//;
     return $data;
 }
 
+# non-blocking version of read_line. if no timeout passed, will block
 sub read_line {
-    my ($self) = @_;
-    my $line = $self->_socket->getline
-        or return;
+    my ($self,$timeout) = @_;
+    my $line;
+
+    my $rv = $self->connection->nb_getline($line);
+    return unless $rv;          # EOF or error
+
+    if ($rv eq '0E0') {         # we do not have a full line
+      while ($rv eq '0E0' && $self->connection->can_read($timeout)) {
+        $rv = $self->connection->nb_getline($line);
+        return unless $rv; # EOF or error. should report error somewhere...
+      }
+      return if $rv eq '0E0';   # got timeout from can_read
+    }
     $line =~ s/\r\n$//;
     return split(' ', $line);
 }
@@ -174,7 +193,7 @@ sub read_line {
 sub send {
     my $self = shift;
     my ($data) = @_;
-    $self->_socket->print($data."\r\n");
+    $self->connection->_socket->print($data."\r\n");
 }
 
 sub handle_info {
@@ -209,7 +228,7 @@ sub parse_msg {
     $subscription->message_count++;
     $self->message_count++;
 
-    if ($subscription->defined_max && $subscription->message_count >= $subscription->max_msgs) { 
+    if ($subscription->defined_max && $subscription->message_count >= $subscription->max_msgs) {
         $self->_remove_subscription($subscription);
     }
 
@@ -220,13 +239,7 @@ sub wait_for_op {
     my $self = shift;
     my $timeout = shift;        # in seconds; can be fractional
 
-    if (defined $timeout) {
-        unless(IO::Select->new($self->_socket)->can_read($timeout)) {
-          return;
-        }
-    }
-
-    my ($op, @args) = $self->read_line;
+    my ($op, @args) = $self->read_line($timeout);
     return unless defined $op;
 
     if ($op eq 'MSG') {
@@ -253,7 +266,7 @@ sub next_sid {
 
 sub close {
     my $self = shift;
-    $self->_socket->close;
+    $self->connection->_socket->close;
 }
 
 sub new_inbox { sprintf("_INBOX.%08X%08X%06X", rand(2**32), rand(2**32), rand(2**24)); }

--- a/lib/Net/NATS/Connection.pm
+++ b/lib/Net/NATS/Connection.pm
@@ -93,7 +93,7 @@ sub nb_getline {
     if (!defined $count) {
       return '0E0' if $! == EWOULDBLOCK; # we handle this error
 
-      $self->error($!);                  # remember the error for later
+      $self->error = $!;               # remember the error for later
       $_[0] = $self->buffer;           # return whatever we read
       return length($_[0]);
     }
@@ -140,7 +140,7 @@ sub nb_read {
     if (!defined $count) {
       return '0E0' if $! == EWOULDBLOCK; # we handle this error
 
-      $self->error($!);                  # remember the error for later
+      $self->error = $!;                 # remember the error for later
       $_[0] = $self->buffer;             # return whatever we read
       return length($_[0]);
     }

--- a/lib/Net/NATS/Connection.pm
+++ b/lib/Net/NATS/Connection.pm
@@ -66,6 +66,13 @@ sub can_read {
   return IO::Select->new($self->_socket)->can_read(@_);
 }
 
+# block until the handle is ready to write, with optional timeout.
+sub can_write {
+  my $self = shift;
+
+  return IO::Select->new($self->_socket)->can_write(@_);
+}
+
 
 # implement non-blocking getline() function by managing our own data buffer
 # based on sample code from "Network Programming with Perl" by L.D. Stein.
@@ -107,7 +114,6 @@ sub nb_getline {
       $idx = index($self->buffer, $/, $self->eobuf);
       # if not found, pretend this was EWOULDBLOCK
       if ($idx < 0) {
-        print "g simulating WOULDBLOCK\n";
         $self->eobuf = length $self->buffer;
         return '0E0';
       }

--- a/lib/Net/NATS/Connection.pm
+++ b/lib/Net/NATS/Connection.pm
@@ -1,4 +1,5 @@
 package Net::NATS::Connection;
+use strict;
 
 use Class::XSAccessor {
     constructors => [ '_new' ],
@@ -6,9 +7,16 @@ use Class::XSAccessor {
         'socket_args',
         '_socket',
     ],
+    lvalue_accessors => [
+        'buffer',
+        'eobuf',
+        'eof',
+        'error',
+    ],
 };
 
 use IO::Socket::INET;
+use Errno 'EWOULDBLOCK';
 
 sub new {
     my $class = shift;
@@ -19,6 +27,8 @@ sub new {
     my $socket = IO::Socket::INET->new(%{$self->socket_args})
         or return;
     $self->_socket($socket);
+    $socket->blocking(0);
+    $self->flush();
 
     return $self;
 }
@@ -35,6 +45,125 @@ sub upgrade {
         or return;
 
     $self->_socket($socket);
+    $socket->blocking(0);
+    $self->flush();
+}
+
+# clear out the buffered data
+sub flush {
+    my $self = shift;
+
+    $self->buffer = '';
+    $self->eobuf = 0;
+    $self->eof = 0;
+    $self->error = '';
+}
+
+# test if we have data on the handle, with optional timeout.
+sub can_read {
+  my $self = shift;
+
+  return IO::Select->new($self->_socket)->can_read(@_);
+}
+
+
+# implement non-blocking getline() function by managing our own data buffer
+# based on sample code from "Network Programming with Perl" by L.D. Stein.
+
+# $bytes = $self->nb_getline($data);
+# data is stored in $data, returns number of bytes on success
+# returns undef on error and sets $self->error, $data has any partial read
+# returns 0 on EOF, $data has partial read
+# returns 0E0 if would block (ie, not a full line read), data is unchanged.
+
+sub nb_getline {
+  my $self = shift;
+
+  return 0 if $self->eof;       # previous read reached EOF
+  return undef if $self->error; # previous read encountered error
+
+  # look up position of EOL in the buffer
+  my $idx = index($self->buffer, $/);
+  if ($idx < 0) {
+    # EOL was not found, so suck in more data if we can
+    $self->eobuf = length $self->buffer;
+    # append to our buffer from the file handle if any data is there.
+    my $count = sysread($self->_socket,$self->buffer,1024,$self->eobuf);
+
+    if (!defined $count) {
+      return '0E0' if $! == EWOULDBLOCK; # we handle this error
+
+      $self->error($!);                  # remember the error for later
+      $_[0] = $self->buffer;           # return whatever we read
+      return length($_[0]);
+    }
+    elsif ($count == 0) { # EOF
+      $self->eof = 1;           # remember for later
+      $_[0] = $self->buffer;    # return whatever we read
+      return length($_[0]);
+    }
+    else {
+      # look for EOL again in the newly read data
+      $idx = index($self->buffer, $/, $self->eobuf);
+      # if not found, pretend this was EWOULDBLOCK
+      if ($idx < 0) {
+        print "g simulating WOULDBLOCK\n";
+        $self->eobuf = length $self->buffer;
+        return '0E0';
+      }
+    }
+  }
+
+  # we successfully read what we needed up to a new line
+  $_[0] = substr($self->buffer,0,$idx + length($/));
+  substr($self->buffer,0,$idx + length($/)) = '';
+  $self->eobuf = length $self->buffer;
+  return length($_[0]);
+}
+
+
+# implement read() function upon our data buffer.
+sub nb_read {
+  my $self = shift;
+  my $length = $_[1];
+
+  return 0 if $self->eof;       # previous read reached EOF
+  return undef if $self->error; # previous read encountered error
+
+  # do we have enough data?
+  if (length $self->buffer < $length) {
+    # not enough, so suck in more data if we can
+    $self->eobuf = length $self->buffer;
+    # append to our buffer from the file handle if any data is there.
+    my $count = sysread($self->_socket,$self->buffer,1024,$self->eobuf);
+
+    if (!defined $count) {
+      return '0E0' if $! == EWOULDBLOCK; # we handle this error
+
+      $self->error($!);                  # remember the error for later
+      $_[0] = $self->buffer;             # return whatever we read
+      return length($_[0]);
+    }
+    elsif ($count == 0) { # EOF
+      $self->eof = 1;           # remember for later
+      $_[0] = $self->buffer;    # return whatever we read
+      return length($_[0]);
+    }
+    else {
+      # check length again
+      $self->eobuf = length $self->buffer;
+      # if not, pretend this was EWOULDBLOCK
+      if ($self->eobuf < $length) {
+        return '0E0';
+      }
+    }
+  }
+
+  # we successfully read what we needed
+  $_[0] = substr($self->buffer,0,$length);
+  substr($self->buffer,0,$length) = '';
+  $self->eobuf = length $self->buffer;
+  return length($_[0]);
 }
 
 1;


### PR DESCRIPTION
The timeout was improperly implemented using select() on a buffered file
handle. This cannot work because there will be data to use in the buffer even
if the handle is not ready to read, thus we deadlock.

We must use our own buffering so we know to call select() only when we are
certain we need to fetch more data from the handle.
