### PR TITLE
Missing scope for $SSL_ERROR

### DIFF
--- a/lib/Net/NATS/Connection.pm
+++ b/lib/Net/NATS/Connection.pm
@@ -42,7 +42,7 @@ sub upgrade {
     }
 
     my $socket = IO::Socket::SSL->start_SSL($self->_socket, %{$self->socket_args})
-        or die "failed to start_SSL: error=$!, ssl_error=$SSL_ERROR";
+        or die "failed to start_SSL: error=$!, ssl_error=$IO::Socket::SSL_ERROR";
 
     $self->_socket($socket);
     $socket->blocking(0);


### PR DESCRIPTION
Without the change, I get–

perl -MIO::Socket -MNet::NATS::Client -E ''
Global symbol "$SSL_ERROR" requires explicit package name at … perl5/lib/perl5/Net/NATS/Connection.pm line 45.
Compilation failed in require at … lib/perl5/Net/NATS/Client.pm line 27.
BEGIN failed--compilation aborted at … perl5/lib/perl5/Net/NATS/Client.pm line 27.
Compilation failed in require.
BEGIN failed--compilation aborted.


Thanks for looking!